### PR TITLE
MidiTrack.insertNote() uses NoteOff to finish the note

### DIFF
--- a/midi/src/main/java/com/pdrogfer/mididroid/MidiTrack.java
+++ b/midi/src/main/java/com/pdrogfer/mididroid/MidiTrack.java
@@ -165,7 +165,7 @@ public class MidiTrack
     {
 
         insertEvent(new NoteOn(tick, channel, pitch, velocity));
-        insertEvent(new NoteOn(tick + duration, channel, pitch, 0));
+        insertEvent(new NoteOff(tick + duration, channel, pitch, 0));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
MidiTrack.insertNote() now inserts one NoteOn and one NoteOff event instead of a second NoteOn with 0 velocity
